### PR TITLE
fix the scss convert error.

### DIFF
--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -1,3 +1,5 @@
+@charset "utf-8";
+
 /**
  * Reset some basic elements
  */

--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -1,3 +1,5 @@
+@charset "utf-8";
+
 /**
  * Site header
  */

--- a/_sass/_syntax-highlighting-monokai.scss
+++ b/_sass/_syntax-highlighting-monokai.scss
@@ -1,3 +1,5 @@
+@charset "utf-8";
+
 .hll { background-color: #49483e }
 .c { color: #75715e } /* Comment */
 .err { color: #960050; background-color: #1e0010 } /* Error */

--- a/_sass/_syntax-highlighting-native.scss
+++ b/_sass/_syntax-highlighting-native.scss
@@ -1,3 +1,5 @@
+@charset "utf-8";
+
 .highlight {
 
 .hll { background-color: #404040 }

--- a/_sass/_syntax-highlighting.scss
+++ b/_sass/_syntax-highlighting.scss
@@ -1,3 +1,5 @@
+@charset "utf-8";
+
 /**
  * Syntax highlighting styles
  */


### PR DESCRIPTION
Fix the scss convert error.
Add [@charset "utf-8";] to every scss files then [jykell build] can build with no error.

OS: Win10 64bit zh_CN
Ruby: 2.3.3p222
Sass: 3.4.23