### PR TITLE
Fix scss convert with none-ANSI charactors.

### DIFF
--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -1,3 +1,5 @@
+@charset "utf-8";
+
 /**
  * Site header
  */


### PR DESCRIPTION
The file default encoding is ANSI, so some none-ANSI characters can not be recognized.